### PR TITLE
Add Tampa Devs (again?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Join these local Slack channels in Alabama, Arkansas, Florida, Georgia, Kentucky
   - [Orlando Devs](https://orlandodevs.com/slack) - Orlando
   - [Suncoast Developers Guild](https://suncoast-devs.slack.com/) - St. Petersburg
   - [Tampa Bay Tech](http://tampabaytech.org/slack/) - Tampa Bay
+  - [Tampa Devs](https://tampadevs.com) - Tampa Devs
 - GA
   - [TechSAV](https://techsav.co/) - Savannah
   - [Tech 404](http://tech404.io/) - Atlanta


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

# Add a Slack Group

I added the tampa devs slack group a few months ago, but im not seeing the listing again on the readme. This is another PR to add it back in:

Previous PR for reference:

https://github.com/thisdot/tech-community-slacks/pull/240
