### PR TITLE
Add kubecon to the Conferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ From Alaska, Hawaii and Washington down to California there are several local ch
 - [CTO Craft Con](https://conference.ctocraft.com) 
 - [Mobile Era](http://mobileera.herokuapp.com/), Norway - discussions about mobile native, mobile web, PWA development
 - [ngVikings](http://ngvikings.herokuapp.com/), Nordics - discussions about Angular and its ecosystem
+- [KubeCon + CloudnativeCon](https://communityinviter.com/apps/cloud-native/cncf), CNCF - discussions about cloud native ecosystem, its technologies, and usecases
 
 # Bonus channels
 


### PR DESCRIPTION
adding slack channel to public slack communities of kubecon which is about cloud native technologies

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

# Add a Slack Group

- [ ] Suggestion is not a duplicate
- [ ] Suggestion is placed in the proper country according the slack channel’s demographic or if it’s a general channel, it’s placed in the appropriate category
- [ ] Name and link are accurate
- [ ] Brief description of the channel is accurate and properly typed

# Remove a Slack Group

- [ ] Name of Slack group is present
- [ ] Reason for requesting removal is present
