### PR TITLE
Remove Denver Devs (defunct)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ From Alaska, Hawaii and Washington down to California there are several local ch
   - [Sacramento Javascript Meetup](https://sac-tech.herokuapp.com/)
 - CO - **in Colorado there are several channels:**
   - [Denver Tech Talk](https://denvertechtalk.com/)
-  - [Denver Devs](https://denverdevs.org/)
   - [Tech Friends](https://www.gettechfriends.com/)
   - [Fort Collins Internet Professionals](http://fcip.slack.com/)
   - [Colorado Springs Developers](https://coloradospringsdevs.herokuapp.com/)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

Denver Devs is shutting down (deleting their discord) today: https://denverdevs.org/

# Add a Slack Group

- [ ] Suggestion is not a duplicate
- [ ] Suggestion is placed in the proper country according the slack channel’s demographic or if it’s a general channel, it’s placed in the appropriate category
- [ ] Name and link are accurate
- [ ] Brief description of the channel is accurate and properly typed

# Remove a Slack Group

- [x] Name of Slack group is present
- [x] Reason for requesting removal is present
