### PR TITLE
Fix link to Traingle Developers Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Join these local Slack channels in Alabama, Arkansas, Florida, Georgia, Kentucky
   - [Louisville.io](http://slackin.louisville.io/) - Louisville
 - NC
   - [Charlotte Devs](https://slack.charlottedevs.com/) - Charlotte
-  - [Triangle Devs](https://triangle-devs-slack-inviter.herokuapp.com/) - Raleigh/Durham
+  - [Triangle Devs](https://triangledevslack.com/) - Raleigh/Durham
 - TN
   - [Chadev](https://chadev.com) - Chattanooga
   - [Devanooga](https://www.devanooga.com/slack/) - Chattanooga


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

# Add a Slack Group

- [x] Suggestion is not a duplicate
- [x] Suggestion is placed in the proper country according the slack channel’s demographic or if it’s a general channel, it’s placed in the appropriate category
- [x] Name and link are accurate
- [x] Brief description of the channel is accurate and properly typed

# Remove a Slack Group

- [x] Name of Slack group is present
- [x] Reason for requesting removal is present

## What Changed
* The link to join the Triangle Developer's Slack has been updated since Heroku deprecated their hobby-tier instances
