### PR TITLE
Update toronto links

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,10 +272,7 @@ From Alaska, Hawaii and Washington down to California there are several local ch
 - BC - [Victoria Developers (YYJ Tech)](https://yyj-tech.ca/)
 - BC - [Victoria Women in Tech (YYJ Tech Ladies)](http://yyjtechladies.com/) Victoria
 - ON - [Ottawa Startups](https://ottawastartups.slack.com/messages/C0408SPU4/) Victoria
-- ON - [TorontoJS](https://torontojs.com/) Toronto
-- ON - [YOWDev](http://yowdev-slackin.herokuapp.com/) Ottawa
-- ON - [CodePen Ottawa](http://codepen-ott.herokuapp.com/) Ottawa
-- QC - [Sketch MTL](http://sketchmtl.now.sh/) Montreal
+- ON - [TorontoJS](https://torontojs.com/) Toronto JS
 - QC - [Women In Tech Montreal](https://witmgroup-slack.herokuapp.com/) Montreal
 - NS - [Halihax](https://www.halihax.com/) Halifax
 

--- a/README.md
+++ b/README.md
@@ -272,8 +272,7 @@ From Alaska, Hawaii and Washington down to California there are several local ch
 - BC - [Victoria Developers (YYJ Tech)](https://yyj-tech.ca/)
 - BC - [Victoria Women in Tech (YYJ Tech Ladies)](http://yyjtechladies.com/) Victoria
 - ON - [Ottawa Startups](https://ottawastartups.slack.com/messages/C0408SPU4/) Victoria
-- ON - [Startup6ix](http://startup6ix.com/) in Toronto
-- ON - [TorontoJS](http://slack.torontojs.com/) Toronto
+- ON - [TorontoJS](https://torontojs.com/) Toronto
 - ON - [YOWDev](http://yowdev-slackin.herokuapp.com/) Ottawa
 - ON - [CodePen Ottawa](http://codepen-ott.herokuapp.com/) Ottawa
 - QC - [Sketch MTL](http://sketchmtl.now.sh/) Montreal


### PR DESCRIPTION
Torontojs is now pointing to the website, where people can join slack.

I also removed a bunch of links from the Canada section. All of them are dead links. Also tried some variants and googling.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

# Add a Slack Group

- [X ] Suggestion is not a duplicate
- [ X] Suggestion is placed in the proper country according the slack channel’s demographic or if it’s a general channel, it’s placed in the appropriate category
- [X] Name and link are accurate
- [X ] Brief description of the channel is accurate and properly typed

# Remove a Slack Group

- [X ] Name of Slack group is present
- [ X] Reason for requesting removal is present
