### PR TITLE
Removing New Haven IO from the list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,6 @@ If you would like to add to the list, please see our [contribution guidelines](.
 
 Where the morning can start with 80°F, rain 10" at noon, and everybody drinks Dunkin’. The home for Harvard, MIT, Yale, Brown, and the W3C has a blossoming tech comunity:
 
-- CT - [New Haven.io](https://newhaven.io)
-
 ### Mid-Atlantic
 
 If you live in Delaware, Maryland, New Jersey, New York, Pennsylvania or Washington D.C., it is worth taking a look at these channels:


### PR DESCRIPTION
We're a local group and we've been getting too many remote members joining from this list. We'd like to remove ourselves.

I'm one of the admins over there, and you can find me on the group's about page (https://newhaven.io/about/).

I appreciate what y'all are doing, but we just don't need to be on this list anymore.
